### PR TITLE
chore: sync dotfiles (zsh, tmux, alacritty, ghostty, nvim, claude) + bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -74,6 +74,7 @@ for f in "$REPO_DIR"/zsh/oh-my-zsh/custom/*.zsh; do
 done
 
 install_file "$REPO_DIR/tmux/.tmux.conf"           "$HOME/.tmux.conf"
+install_file "$REPO_DIR/gitmux/gitmux.conf"        "$HOME/.config/gitmux/gitmux.conf"
 install_file "$REPO_DIR/alacritty/alacritty.toml"  "$HOME/.config/alacritty/alacritty.toml"
 install_file "$REPO_DIR/ghostty/config"            "$HOME/.config/ghostty/config"
 install_file "$REPO_DIR/nvim/init.vim"             "$HOME/.config/nvim/init.vim"

--- a/gitmux/gitmux.conf
+++ b/gitmux/gitmux.conf
@@ -1,0 +1,7 @@
+# gitmux config for the tmux status bar (referenced via `gitmux -cfg` in tmux/.tmux.conf).
+#
+# Drops the redundant remote-branch name (origin/<branch>) from gitmux's default
+# layout. Keeps the local branch, the ahead/behind divergence counts (↑·/↓·), and
+# the working-tree flags. Run `gitmux -printcfg` to see all defaults.
+tmux:
+    layout: [branch, divergence, " - ", flags]

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -26,7 +26,7 @@
   setw -g window-status-current-format '#[fg=#83a598]#[bg=#282828]▌#[bg=#504945]#[fg=#ebdbb2]#[bold] #I #{?#{m:▶*,#W},#[fg=#fabd2f]▶ ,#{?#{m:⏸*,#W},#[fg=#fe8019]⏸ ,#{?#{m:✓*,#W},#[fg=#b8bb26]✓ ,}}}#[fg=#ebdbb2]#{=25:#{?#{||:#{m:▶*,#W},#{||:#{m:⏸*,#W},#{m:✓*,#W}}},#{s/^[^ ]* //:pane_title},#W}} #[nobold]#[fg=#83a598]#[bg=#282828]▐'
   setw -g window-status-separator ''
   set -g status-right-length 200
-  set -g status-right '#[fg=#1d2021,bg=#83a598,bold] #{kubectx_context}:#{kubectx_namespace} #[fg=#ebdbb2,bg=#282828] #(gitmux "#{pane_current_path}")'
+  set -g status-right '#[fg=#1d2021,bg=#83a598,bold] #{kubectx_context}:#{kubectx_namespace} #[fg=#ebdbb2,bg=#282828] #(gitmux -cfg ~/.config/gitmux/gitmux.conf "#{pane_current_path}")'
   set -g pane-border-style 'fg=#504945'
   set -g pane-active-border-style 'fg=#fabd2f'
   set -g message-style 'fg=#1d2021,bg=#fabd2f,bold'

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -19,8 +19,11 @@
   set -g status-style 'fg=#ebdbb2,bg=#282828'
   set -g status-left-length 40
   set -g status-left '#[fg=#1d2021,bg=#b8bb26,bold] #S #{?client_prefix,#[fg=#1d2021]#[bg=#fabd2f] PREFIX ,}#[fg=#b8bb26,bg=#282828,nobold]'
-  setw -g window-status-format '#[fg=#a89984,bg=#3c3836] #I #{?pane_title,#{=25:pane_title},#W} '
-  setw -g window-status-current-format '#[fg=#1d2021,bg=#fabd2f,bold] #I #{?pane_title,#{=25:pane_title},#W} '
+  # Claude state colours only the icon (no filled blocks): yellow ▶ running, orange ⏸ waiting,
+  # green ✓ done. Icon/state from the hook's window name (#W); summary text from Claude's pane_title.
+  # Current window: subtle lighter bg + bright blue ▌…▐ flank bars.
+  setw -g window-status-format '#[fg=#a89984]#[bg=#3c3836] #I #{?#{m:▶*,#W},#[fg=#fabd2f]#[bold]▶#[nobold] ,#{?#{m:⏸*,#W},#[fg=#fe8019]#[bold]⏸#[nobold] ,#{?#{m:✓*,#W},#[fg=#b8bb26]#[bold]✓#[nobold] ,}}}#[fg=#a89984]#{=25:#{?#{||:#{m:▶*,#W},#{||:#{m:⏸*,#W},#{m:✓*,#W}}},#{s/^[^ ]* //:pane_title},#W}} #[fg=#3c3836]#[bg=#282828]'
+  setw -g window-status-current-format '#[fg=#83a598]#[bg=#282828]▌#[bg=#504945]#[fg=#ebdbb2]#[bold] #I #{?#{m:▶*,#W},#[fg=#fabd2f]▶ ,#{?#{m:⏸*,#W},#[fg=#fe8019]⏸ ,#{?#{m:✓*,#W},#[fg=#b8bb26]✓ ,}}}#[fg=#ebdbb2]#{=25:#{?#{||:#{m:▶*,#W},#{||:#{m:⏸*,#W},#{m:✓*,#W}}},#{s/^[^ ]* //:pane_title},#W}} #[nobold]#[fg=#83a598]#[bg=#282828]▐'
   setw -g window-status-separator ''
   set -g status-right-length 200
   set -g status-right '#[fg=#1d2021,bg=#83a598,bold] #{kubectx_context}:#{kubectx_namespace} #[fg=#ebdbb2,bg=#282828] #(gitmux "#{pane_current_path}")'


### PR DESCRIPTION
## What

Snapshot and modernize personal dotfiles into this repo with a single `bootstrap.sh` to deploy them.

- **bootstrap.sh / Brewfile**: reproducible setup; install packages and link configs.
- **zsh**: `.zshrc`/`.zprofile`, Powerlevel10k config, keratoconus-tuned p10k variant.
- **tmux**: Claude Code integration (passthrough, extended-keys) and a Gruvbox Dark Hard status line. Window list now colors Claude state icons — yellow ▶ running, orange ⏸ waiting, green ✓ done — reading state from the hook window name (`#W`) and summary text from Claude's `pane_title`.
- **alacritty / ghostty**: Gruvbox Dark Hard terminals; Shift+Enter newline binding for Claude Code.
- **nvim**: `init.vim` + coc settings.
- **claude**: Gruvbox Dark Hard theme, installed via bootstrap.
- Removes legacy vim/bash submodule cruft.

## Why

Centralize machine setup so a new Mac is reproducible from one repo, with accessibility (keratoconus) baked into the terminal stack.